### PR TITLE
update makefile to work with anaconda envs

### DIFF
--- a/bem_pycuda/tree/Makefile
+++ b/bem_pycuda/tree/Makefile
@@ -4,9 +4,11 @@ SWIG_OPTS = -c++ -python
 CC = g++
 OPTS = -fPIC -O3 -funroll-loops -msse3 -fopenmp
 
+PY_BASE_DIR=$(shell python -c "from distutils.spawn import find_executable;import sys;t=find_executable('python')[:-11];sys.stdout.write(t)")
 PY_VER=$(shell python -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)")
-PY_INC=/usr/include/python$(PY_VER)
-PY_LIB=/usr/include/python$(PY_VER)
+PY_INC=$(PY_BASE_DIR)/include/python$(PY_VER)m
+PY_LIB=$(PY_BASE_DIR)/include/python$(PY_VER)
+NUMPY_LIB=$(PY_BASE_DIR)/lib/python$(PY_VER)/site-packages/numpy/core/include
 
 all: calc_mult mult dir link
 
@@ -20,11 +22,11 @@ dir: direct.i
 	$(SWIG) $(SWIG_OPTS) $?
 
 link:  
-	$(CC) $(OPTS) -c calculateMultipoles.cpp calculateMultipoles_wrap.cxx -I $(PY_INC) -I $(PY_LIB)
+	$(CC) $(OPTS) -c calculateMultipoles.cpp calculateMultipoles_wrap.cxx -I $(PY_INC) -I $(PY_LIB) -I $(NUMPY_LIB)
 	$(CC) $(OPTS) -shared $? -o _calculateMultipoles.so calculateMultipoles.o calculateMultipoles_wrap.o
-	$(CC) $(OPTS) -c multipole.cpp multipole_wrap.cxx -I $(PY_INC) -I $(PY_LIB)
+	$(CC) $(OPTS) -c multipole.cpp multipole_wrap.cxx -I $(PY_INC) -I $(PY_LIB) -I $(NUMPY_LIB)
 	$(CC) $(OPTS) -shared $? -o _multipole.so multipole.o multipole_wrap.o
-	$(CC) $(OPTS) -c direct.cpp direct_wrap.cxx -I $(PY_INC) -I $(PY_LIB)
+	$(CC) $(OPTS) -c direct.cpp direct_wrap.cxx -I $(PY_INC) -I $(PY_LIB) -I $(NUMPY_LIB)
 	$(CC) $(OPTS) -shared $? -o _direct.so direct.o direct_wrap.o
 
 clean:

--- a/util/Makefile
+++ b/util/Makefile
@@ -4,9 +4,11 @@ SWIG_OPTS = -c++ -python
 CC = g++ 
 OPTS = -fPIC -O3 -funroll-loops -msse3 -fopenmp
 
+PY_BASE_DIR=$(shell python -c "from distutils.spawn import find_executable;import sys;t=find_executable('python')[:-11];sys.stdout.write(t)")
 PY_VER=$(shell python -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)")
-PY_INC=/usr/include/python$(PY_VER)
-PY_LIB=/usr/include/python$(PY_VER)
+PY_INC=$(PY_BASE_DIR)/include/python$(PY_VER)m
+PY_LIB=$(PY_BASE_DIR)/include/python$(PY_VER)
+NUMPY_LIB=$(PY_BASE_DIR)/lib/python$(PY_VER)/site-packages/numpy/core/include
 
 all: swig link
 
@@ -14,7 +16,7 @@ swig: semi_analyticalwrap.i
 	$(SWIG) $(SWIG_OPTS) $?
 
 link:  
-	$(CC) $(OPTS) -c semi_analyticalwrap.cpp semi_analyticalwrap_wrap.cxx -I $(PY_INC) -I $(PY_LIB)
+	$(CC) $(OPTS) -c semi_analyticalwrap.cpp semi_analyticalwrap_wrap.cxx -I $(PY_INC) -I $(PY_LIB) -I $(NUMPY_LIB)
 	$(CC) $(OPTS) -shared $? -o _semi_analyticalwrap.so semi_analyticalwrap.o semi_analyticalwrap_wrap.o
 
 clean:


### PR DESCRIPTION
Locations of Python dependencies were hardcoded in for system python,
specifically, system python on Ubuntu.  Now it looks for the location of
the Python binary on $PATH and then uses that location as a basis for
determining the relative locations of the necessary libraries.

Tested on Arch and Ubuntu using both Anaconda and system Python.