### PR TITLE
Update README - last dependencies tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We summarize the commands to install PyCUDA on Ubuntu here:
     > cd src
     > wget https://pypi.python.org/packages/source/p/pycuda/pycuda-2015.1.3.tar.gz
     > tar -xvzf pycuda-2015.1.3.tar.gz
-    > cd pycuda-2013.1.1
+    > cd pycuda-2015.1.3
     > python configure.py --cuda-root=/usr/local/cuda
     > make
     > sudo make install

--- a/README.md
+++ b/README.md
@@ -25,15 +25,9 @@ corresponding commands in your flavor of Linux to install.
 * NVCC 7.0 
 * PyCUDA 2015.1.3
 
-#### Python
-Python is available by default on Ubuntu.
+#### Python, Numpy and SWIG
 
-#### Numpy and SWIG
-
-Install numpy and SWIG by running 
-the following in the command line:
-
-    > sudo apt-get install python-numpy swig
+To install the specific version of these packages we recommend using either [conda](http://conda.pydata.org/docs/get-started.html) or [pip](http://python-packaging-user-guide.readthedocs.org/en/latest/installing/).
 
 #### NVCC
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ C++ using SWIG.
 The following instructions assume that the operating system is Ubuntu. Run the 
 corresponding commands in your flavor of Linux to install.
 
-### Dependencies
-* Python
-* Numpy
-* SWIG
-* NVCC
-* PyCUDA
+### Dependencies (last tested)
+* Python 2.7.11
+* Numpy 1.10.4
+* SWIG 3.0.8
+* NVCC 7.0 
+* PyCUDA 2015.1.3
 
 #### Python
 Python is available by default on Ubuntu.
@@ -47,8 +47,8 @@ We summarize the commands to install PyCUDA on Ubuntu here:
     > cd $HOME
     > mkdir src
     > cd src
-    > wget https://pypi.python.org/packages/source/p/pycuda/pycuda-2013.1.1.tar.gz
-    > tar -xvzf pycuda-2013.1.1.tar.gz
+    > wget https://pypi.python.org/packages/source/p/pycuda/pycuda-2015.1.3.tar.gz
+    > tar -xvzf pycuda-2015.1.3.tar.gz
     > cd pycuda-2013.1.1
     > python configure.py --cuda-root=/usr/local/cuda
     > make
@@ -59,7 +59,7 @@ Test the installation by running the following:
     > cd test
     > python test_driver.py
 
-PyGBe has been run and tested on Ubuntu 12.04 and 13.10. The versions of the dependencies used were python 2.7, numpy 1.6 and 1.7, swig 2.0, nvcc 5.5 and pycuda 1.1.
+PyGBe has been run and tested on Ubuntu 12.04, 13.10 and 15.04. 
 
 ### Compiling PyGBe
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ corresponding commands in your flavor of Linux to install.
 * NVCC 7.0 
 * PyCUDA 2015.1.3
 
-#### Python, Numpy and SWIG
+#### Python and Numpy 
 
 To install the specific version of these packages we recommend using either [conda](http://conda.pydata.org/docs/get-started.html) or [pip](http://python-packaging-user-guide.readthedocs.org/en/latest/installing/).
+
+#### SWIG
+
+To install SWIG we recommend using either `conda` or your distribution package manager.  
 
 #### NVCC
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To install the specific version of these packages we recommend using either [con
 
 #### SWIG
 
-To install SWIG we recommend using either `conda` or your distribution package manager.  
+To install SWIG we recommend using either `conda`, your distribution package manager or [SWIG's website](http://www.swig.org/download.html).  
 
 #### NVCC
 


### PR DESCRIPTION
I replace the last version of each dependency that I tested on Blackbird. I was wondering if in the installation instructions for python, numpy and swig we should change them for a `conda install` version, because the default versions that come with Ubuntu for example, are usually older than the ones from Anaconda. 

@gforsyth  and @cdcooper84  what do you think?