### PR TITLE
Fixing bibtex entry.

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -24,7 +24,7 @@ bibliography: paper.bib
 PyGBe—pronounced _pigbē_—is a Python code to apply the boundary element method for molecular-electrostatics 
 calculations in a continuum model.
 It computes solvation energies for proteins modeled with any number of dielectric regions. 
-The mathematical formulation follows Yoon and Lenhoff (1990) for solving the Poisson-Boltzmann equation of the [implicit-solvent](https://en.wikipedia.org/wiki/Implicit_solvation) model in integral form.
+The mathematical formulation follows @YoonLenhoff1990 for solving the Poisson-Boltzmann equation of the [implicit-solvent](https://en.wikipedia.org/wiki/Implicit_solvation) model in integral form.
 
 PyGBe achieves both algorithmic and hardware acceleration.
 The solution algorithm uses a [Barnes-Hut](https://en.wikipedia.org/wiki/Barnes–Hut_simulation) treecode to accelerate each iteration of a GMRES solver to O(N logN), for N unknowns. 


### PR DESCRIPTION
Without this change the references section of the JOSS paper were empty. The compiled version of this PDF looks like this: [10.21105.joss.00043.pdf](https://github.com/barbagroup/pygbe/files/377243/10.21105.joss.00043.pdf)
