### PR TITLE
Add in Cuda 7.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ corresponding commands in your flavor of Linux to install.
 * Python 2.7.11
 * Numpy 1.11.0
 * SWIG 3.0.8
-* NVCC 7.0 
+* NVCC 7.5 
     * gcc < 4.10
-* PyCUDA 2016.1.1
+* PyCUDA 2016.1.3
 
 #### Python and Numpy 
 
@@ -43,9 +43,9 @@ We summarize the commands to install PyCUDA on Ubuntu here:
     > cd $HOME
     > mkdir src
     > cd src
-    > wget https://pypi.python.org/packages/source/p/pycuda/pycuda-2015.1.3.tar.gz
-    > tar -xvzf pycuda-2015.1.3.tar.gz
-    > cd pycuda-2015.1.3
+    > wget https://github.com/inducer/pycuda/archive/v2016.1.2.tar.gz
+    > tar -xvzf pycuda-2016.1.2.tar.gz
+    > cd pycuda-2016.1.2
     > python configure.py --cuda-root=/usr/local/cuda
     > make
     > sudo make install 

--- a/pygbe/main.py
+++ b/pygbe/main.py
@@ -178,13 +178,13 @@ def check_for_nvcc():
 
 
 def check_nvcc_version():
-    """Check that version of nvcc <= 7.0"""
+    """Check that version of nvcc <= 7.5"""
     verstr = subprocess.check_output(['nvcc', '--version'])
     cuda_ver = re.compile('release (\d\.\d)')
     match = re.search(cuda_ver, verstr)
     version = float(match.group(1))
-    if version > 7.0:
-        sys.exit('PyGBe only supports CUDA <= 7.0\n'
+    if version > 7.5:
+        sys.exit('PyGBe only supports CUDA <= 7.5\n'
                  'Please install an earlier version of the CUDA toolkit\n'
                  'or remove `nvcc` from your PATH to use CPU only.')
 

--- a/pygbe/tree/cuda_kernels.py
+++ b/pygbe/tree/cuda_kernels.py
@@ -1061,7 +1061,7 @@ def kernels(BSZ, Nm, K_fine, P, REAL):
 
     }
 
-    __device__ REAL norm(REAL *x)
+    __device__ REAL mynorm(REAL *x)
     {
         return sqrt(x[0]*x[0] + x[1]*x[1] + x[2]*x[2]);
     }
@@ -1179,7 +1179,7 @@ def kernels(BSZ, Nm, K_fine, P, REAL):
             v21u[i] = v2[i] - v1[i];
         }
 
-        REAL L21 = norm(v21u);
+        REAL L21 = mynorm(v21u);
         axip(v21u, 1/L21, 3);
 
         REAL unit[3] = {0.,0.,1.};
@@ -1235,8 +1235,8 @@ def kernels(BSZ, Nm, K_fine, P, REAL):
 
         // Find panel coordinate system X: 0->1
         cross(y1_panel, y2_panel, Z);
-        REAL Xnorm = norm(X);
-        REAL Znorm = norm(Z);
+        REAL Xnorm = mynorm(X);
+        REAL Znorm = mynorm(Z);
         for (int i=0; i<3; i++)
         {
             X[i] /= Xnorm;
@@ -2296,6 +2296,6 @@ def kernels(BSZ, Nm, K_fine, P, REAL):
     }
 
 
-    """%{'blocksize':BSZ, 'Nmult':Nm, 'K_near':K_fine, 'Ptree':P, 'precision':REAL}, nvcc="nvcc", options=["-use_fast_math","-Xptxas=-v,-abi=no"])
+    """%{'blocksize':BSZ, 'Nmult':Nm, 'K_near':K_fine, 'Ptree':P, 'precision':REAL}, nvcc="nvcc", options=["-use_fast_math"])
 
     return mod


### PR DESCRIPTION
This adds Cuda 7.5 support to PyGBe and also updates the README to reflect the version of PyCUDA used (and the version of Cuda that is supported).   

I've also updated the sphinx docs and already pushed those up to github pages (as per the suggestions made in the review, they now contain the contents of the README)