### PR TITLE
fix array size bug in mesh_sphere/triangulation scripts

### DIFF
--- a/preprocessing_tools/mesh_sphere.py
+++ b/preprocessing_tools/mesh_sphere.py
@@ -82,9 +82,9 @@ x_test = numpy.average(vertex[:,0])
 y_test = numpy.average(vertex[:,1])
 z_test = numpy.average(vertex[:,2])
 if abs(x_test-x0)>1e-12 or abs(y_test-y0)>1e-12 or abs(z_test-z0)>1e-12:
-    print 'Center is not right!'
+    print('Center is not right!')
 
 numpy.savetxt(filename+'.vert', vertex, fmt='%.4f')
 numpy.savetxt(filename+'.face', index_format, fmt='%i')
 
-print 'Sphere with %i faces, radius %f and centered at %f,%f,%f was saved to the file '%(len(index), r, x0, y0, z0)+filename
+print('Sphere with %i faces, radius %f and centered at %f,%f,%f was saved to the file '%(len(index), r, x0, y0, z0)+filename)

--- a/preprocessing_tools/triangulation.py
+++ b/preprocessing_tools/triangulation.py
@@ -104,7 +104,7 @@ def divide_all( vertices, triangles ):
     
     #Stack the triangles together.
     vert_new  = numpy.hstack( (v0,b,a,  b,v1,c,  a,b,c, a,c,v2) ).reshape((-1,3))
-    triang_new = numpy.arange( len(vertices) ).reshape( (-1,3) )
+    triang_new = numpy.arange( len(vert_new) ).reshape( (-1,3) )
     #Now our vertices are duplicated, and thus our triangle structure
     # are unnecesarry.    
     return vert_new, triang_new


### PR DESCRIPTION
Quick fix of a mismatched name and adding in parens for Python 3 `print` statements