### PR TITLE
Updates to field initialization and a small bug fix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@
    input_format
    references
    othersoftware
+   programmatic
 
 
 

--- a/docs/programmatic.rst
+++ b/docs/programmatic.rst
@@ -1,23 +1,54 @@
-Programmatic use of ``PyGBe``
+Programmatic use of PyGBe
 -----------------------------
 
 
-Using ``PyGBe`` within IPython
-==============================
+Using PyGBe within IPython
+==========================
 
+There will be times when you want to run PyGBe within a Python interpreter,
+as opposed to running on the command line. If you need to debug using ``ipdb``
+or to generate figures that require several sequential runs, you're better off
+scripting in Python than in Bash.
+
+The following example would run the Lysozyme example.
+
+.. note:: The first value in the list passed to main must be an empty string.
+          The path to the example folder (``examples/lys``) is relative to
+          wherever the interpreter was started. In this example, we entered the
+          root of the PyGBe repo and then ran ``ipython``
 
 .. code:: python
 
    from pygbe.main import main
     main(['', 'examples/lys'], log_output=False)
 
-   
 
+Useful kwargs
+=============
 
+There are a few keyword arguments you can pass to PyGBe when running from
+IPython that are useful for programmatic work.
 
+``log_output`` : default ``True``
+    If you are debugging you probably don't need to the entirety of
+    PyGBe output written to a log file, this will suspend that logging behavior
+    and only stdout will be written to.
 
-.. code:: console
+``return_output_fname`` : default ``False``
+    If ``True`` then ``main()`` will
+    return the name of the logfile created for the current run
 
-    conda create -n pygbe python=3.5 numpy scipy swig matplotlib
-    source activate pygbe
+``return_results_dict`` : default ``False``
+    If ``True`` then ``main()`` will return a dictionary with the calculated
+    values (if applicable) of the config file used, param file used, any
+    geometry files, the path of the problem, the number of elements and any
+    calculated energy quantities.
 
+.. note:: ``return_results_dict`` will supercede both ``return_output_fname`` and ``log_output`` if used.
+
+``field`` : default ``None``
+    If you are running several runs that are nearly identical, with only a few
+    changes to the configuration, rather than programmatically editing config
+    files to generate each run, you can instead pass in a dictionary of the
+    appropriate values.  This will circumvent the ``initialize_field`` function
+    that reads from the config file.

--- a/docs/programmatic.rst
+++ b/docs/programmatic.rst
@@ -1,0 +1,23 @@
+Programmatic use of ``PyGBe``
+-----------------------------
+
+
+Using ``PyGBe`` within IPython
+==============================
+
+
+.. code:: python
+
+   from pygbe.main import main
+    main(['', 'examples/lys'], log_output=False)
+
+   
+
+
+
+
+.. code:: console
+
+    conda create -n pygbe python=3.5 numpy scipy swig matplotlib
+    source activate pygbe
+

--- a/pygbe/class_initialization.py
+++ b/pygbe/class_initialization.py
@@ -39,7 +39,7 @@ def initialize_surface(field_array, filename, param):
     return surf_array
 
 
-def initialize_field(filename, param):
+def initialize_field(filename, param, field=None):
     """
     Initialize all the regions in the surface to be solved.
 
@@ -47,38 +47,41 @@ def initialize_field(filename, param):
     ---------
     filename   : name of the file that contains the surface information.
     param      : class, parameters related to the surface.
+    field      : dictionary with preloaded field values for programmatic
+                 interaction with PyGBe
 
     Returns
     -------
     field_array: array, contains the Field classes of each region on the surface.
     """
 
-    LorY, pot, E, kappa, charges, coulomb, qfile, Nparent, parent, Nchild, child = readFields(
-        filename)
+    if not field:
+        field = readFields(filename)
 
-    LorY = [int(i) if i != 'NA' else 0 for i in LorY]
-    E = [complex(i) if 'j' in i else param.REAL(i) if i != 'NA' else 0
-         for i in E]
-    kappa = [param.REAL(i) if i != 'NA' else 0 for i in kappa]
-    pot = [int(i) for i in pot]
-    coulomb = [int(i) for i in coulomb]
-    Nfield = len(LorY)
+    field['LorY'] = [int(i) if i != 'NA' else 0 for i in field['LorY']]
+    field['E'] = [complex(i) if 'j' in i else param.REAL(i) if i != 'NA' else 0
+         for i in field['E']]
+    field['kappa'] = [param.REAL(i) if i != 'NA' else 0 for i in field['kappa']]
+    field['pot'] = [int(i) for i in field['pot']]
+    field['coulomb'] = [int(i) for i in field['coulomb']]
+    Nfield = len(field['LorY'])
     field_array = []
     Nchild_aux = 0
     for i in range(Nfield):
-        field_aux = Field(LorY[i], kappa[i], E[i], coulomb[i], pot[i])
+        field_aux = Field(field['LorY'][i], field['kappa'][i], field['E'][i],
+                          field['coulomb'][i], field['pot'][i])
 
-        if int(charges[i]) == 1:  # if there are charges
-            field_aux.load_charges(qfile[i], param.REAL)
-        if int(Nparent[i]) == 1:  # if it is an enclosed region
-            field_aux.parent.append(int(parent[i]))
+        if int(field['charges'][i]) == 1:  # if there are charges
+            field_aux.load_charges(field['qfile'][i], param.REAL)
+        if int(field['Nparent'][i]) == 1:  # if it is an enclosed region
+            field_aux.parent.append(int(field['parent'][i]))
             # pointer to parent surface (enclosing surface)
-        if int(Nchild[i]) > 0:  # if there are enclosed regions inside
-            for j in range(int(Nchild[i])):
-                field_aux.child.append(int(child[Nchild_aux + j])
+        if int(field['Nchild'][i]) > 0:  # if there are enclosed regions inside
+            for j in range(int(field['Nchild'][i])):
+                field_aux.child.append(int(field['child'][Nchild_aux + j])
                                        )  # Loop over children to get pointers
-            Nchild_aux += int(Nchild[i])  # Point to child for next surface
-        if pot[i] == 1:
+            Nchild_aux += int(field['Nchild'][i])  # Point to child for next surface
+        if field['pot'][i] == 1:
             param.E_field.append(i)  # Field where surface energy is calculated
 
         field_array.append(field_aux)

--- a/pygbe/classes.py
+++ b/pygbe/classes.py
@@ -296,9 +296,9 @@ class Surface():
 
         Notes
         -----
-        Uses block-diagonal preconditioner [1]_
+        Uses block-diagonal preconditioner [3]_
 
-        .. [1] Altman, M. D., Bardhan, J. P., White, J. K., & Tidor, B. (2009).
+        .. [3] Altman, M. D., Bardhan, J. P., White, J. K., & Tidor, B. (2009).
            Accurate solution of multi‐region continuum biomolecule electrostatic
            problems using the linearized Poisson–Boltzmann equation with curved
            boundary elements. Journal of computational chemistry, 30(1), 132-153.

--- a/pygbe/main.py
+++ b/pygbe/main.py
@@ -48,6 +48,10 @@ class Logger(object):
         self.terminal.write(message)
         self.log.write(message)
 
+    def flush(self):
+        """Required for Python 3"""
+        pass
+
 
 def read_inputs(args):
     """

--- a/pygbe/main.py
+++ b/pygbe/main.py
@@ -185,19 +185,25 @@ def check_nvcc_version():
 
 
 def main(argv=sys.argv, log_output=True, return_output_fname=False,
-         return_results_dict=False):
+         return_results_dict=False, field=None):
     """
     Run a PyGBe problem, write outputs to STDOUT and to log file in
     problem directory
 
     Arguments
     ----------
-    log_output         : Bool, default True.
-                         If False, output is written only to STDOUT and not
-                         to a log file.
+    log_output : Bool, default True.
+        If False, output is written only to STDOUT and not to a log file.
     return_output_fname: Bool, default False.
-                         If True, function main() returns the name of the
-                         output log file. This is used for the regression tests.
+        If True, function main() returns the name of the
+        output log file. This is used for the regression tests.
+    return_results_dict: Bool, default False.
+        If True, function main() returns the results of the run
+        packed in a dictionary.  Used in testing and programmatic
+        use of PyGBe
+    field : Dictionary, defaults to None.
+         If passed, this dictionary will supercede any config file found, useful in
+         programmatically stepping through slight changes in a problem
 
     Returns
     --------
@@ -278,7 +284,11 @@ def main(argv=sys.argv, log_output=True, return_output_fname=False,
         param.GPU = 0
 
     ### Generate array of fields
-    field_array = initialize_field(configFile, param)
+    if field:
+        field_array = initialize_field(configFile, param, field)
+    else:
+        field_array = initialize_field(configFile, param)
+
 
     ### Generate array of surfaces and read in elements
     surf_array = initialize_surface(field_array, configFile, param)

--- a/pygbe/util/readData.py
+++ b/pygbe/util/readData.py
@@ -315,8 +315,8 @@ def readParameters(param, filename):
 
 def readFields(filename):
     """
-    It reads the physical parameters from the configuration file for each region
-    in the surface and it appends them on the corresponding list.
+    Read the physical parameters from the configuration file for each region
+    in the surface
 
     Arguments
     ----------
@@ -325,6 +325,7 @@ def readFields(filename):
 
     Returns
     -------
+    Dictionary containing:
     LorY    : list, it contains integers, Laplace (1) or Yukawa (2),
                     corresponding to each region.
     pot     : list, it contains integers indicating to calculate (1) or not (2)
@@ -350,17 +351,18 @@ def readFields(filename):
                      surface in the FILE section.
     """
 
-    LorY = []
-    pot = []
-    E = []
-    kappa = []
-    charges = []
-    coulomb = []
-    qfile = []
-    Nparent = []
-    parent = []
-    Nchild = []
-    child = []
+    field = dict()
+    field['LorY'] = []
+    field['pot'] = []
+    field['E'] = []
+    field['kappa'] = []
+    field['charges'] = []
+    field['coulomb'] = []
+    field['qfile'] = []
+    field['Nparent'] = []
+    field['parent'] = []
+    field['Nchild'] = []
+    field['child'] = []
 
     with open(filename, 'r') as f:
         lines = f.readlines()
@@ -368,21 +370,21 @@ def readFields(filename):
             line = line.split()
             if len(line) > 0:
                 if line[0] == 'FIELD':
-                    LorY.append(line[1])
-                    pot.append(line[2])
-                    E.append(line[3])
-                    kappa.append(line[4])
-                    charges.append(line[5])
-                    coulomb.append(line[6])
-                    qfile.append(line[7] if line[7] == 'NA' else
+                    field['LorY'].append(line[1])
+                    field['pot'].append(line[2])
+                    field['E'].append(line[3])
+                    field['kappa'].append(line[4])
+                    field['charges'].append(line[5])
+                    field['coulomb'].append(line[6])
+                    field['qfile'].append(line[7] if line[7] == 'NA' else
                         os.path.join(os.environ.get('PYGBE_PROBLEM_FOLDER'), line[7]))
-                    Nparent.append(line[8])
-                    parent.append(line[9])
-                    Nchild.append(line[10])
-                    for i in range(int(Nchild[-1])):
-                        child.append(line[11 + i])
+                    field['Nparent'].append(line[8])
+                    field['parent'].append(line[9])
+                    field['Nchild'].append(line[10])
+                    for i in range(int(field['Nchild'][-1])):
+                        field['child'].append(line[11 + i])
 
-    return LorY, pot, E, kappa, charges, coulomb, qfile, Nparent, parent, Nchild, child
+    return field
 
 
 def read_surface(filename):


### PR DESCRIPTION
Small bug fix: there was no `flush` method on my `Logger` class thing that kept throwing errors.  Now it won't.  Yay!

Updates to field initialization:

First, in `readFields`, instead of assigning all of the values from the config file to several separate variables, these are all now packed in a dictionary.  This is purely an internal change and has no impact on PyGBe's behavior re: end users.  

Second, in `initialize_field` I've added an optional keyword argument `field` which, if passed in is used in lieu of any values from a local config file.  The goal here is that in cases where we need to run many sequential runs with very small changes made, we can do so within a Python interpreter and make small tweaks to the config dictionary at each run.  

I've added some preliminary documentation on how to use it.
