### PR TITLE
Update cuda

### DIFF
--- a/pygbe/main.py
+++ b/pygbe/main.py
@@ -163,25 +163,12 @@ def check_for_nvcc():
     """Check system PATH for nvcc, exit if not found"""
     try:
         subprocess.check_output(['which', 'nvcc'])
-        check_nvcc_version()
         return True
     except subprocess.CalledProcessError:
         print(
             "Could not find `nvcc` on your PATH.  Is cuda installed?  PyGBe will continue to run but will run significantly slower.  For optimal performance, add `nvcc` to your PATH"
         )
         return False
-
-
-def check_nvcc_version():
-    """Check that version of nvcc <= 7.5"""
-    verstr = subprocess.check_output(['nvcc', '--version']).decode('utf-8')
-    cuda_ver = re.compile('release (\d\.\d)')
-    match = re.search(cuda_ver, verstr)
-    version = float(match.group(1))
-    if version > 7.5:
-        sys.exit('PyGBe only supports CUDA <= 7.5\n'
-                 'Please install an earlier version of the CUDA toolkit\n'
-                 'or remove `nvcc` from your PATH to use CPU only.')
 
 
 def main(argv=sys.argv, log_output=True, return_output_fname=False,

--- a/tests/test_lysozyme.py
+++ b/tests/test_lysozyme.py
@@ -25,10 +25,7 @@ def test_lysozyme(key):
     with open('lysozyme.pickle', 'rb') as f:
         base_results = pickle.load(f)
 
-    if base_results[key] > 0:
-        assert abs(base_results[key] - results[key]) / base_results[key] < 1e-12
-    else:
-        assert base_results[key] == results[key]
+    assert abs(base_results[key] - results[key]) / abs(base_results[key]) < 1e-12
 
 def test_lysozyme_iterations():
     results = get_results()

--- a/tests/test_pgbmut.py
+++ b/tests/test_pgbmut.py
@@ -25,10 +25,7 @@ def test_PGB_mut_sensor(key):
     with open('pgbmut.pickle', 'rb') as f:
         base_results = pickle.load(f)
 
-    if base_results[key] > 0:
-        assert abs(base_results[key] - results[key]) / base_results[key] < 1e-12
-    else:
-        assert base_results[key] == results[key]
+    assert abs(base_results[key] - results[key]) / abs(base_results[key]) < 1e-12
 
 def test_pgbmut_iterations():
     results = get_results()

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -25,10 +25,7 @@ def test_sphere(key):
     with open('sphere.pickle', 'rb') as f:
         base_results = pickle.load(f)
 
-    if base_results[key] > 0:
-        assert abs(base_results[key] - results[key]) / base_results[key] < 1e-12
-    else:
-        assert base_results[key] == results[key]
+    assert abs(base_results[key] - results[key]) / abs(base_results[key]) < 1e-12
 
 def test_sphere_iterations():
     results = get_results()

--- a/tests/test_sphere.py
+++ b/tests/test_sphere.py
@@ -25,7 +25,7 @@ def test_sphere(key):
     with open('sphere.pickle', 'rb') as f:
         base_results = pickle.load(f)
 
-    assert abs(base_results[key] - results[key]) / abs(base_results[key]) < 1e-12
+    assert abs(base_results[key] - results[key]) / abs(base_results[key] + 1e-16) < 1e-12
 
 def test_sphere_iterations():
     results = get_results()

--- a/tests/test_two_spheres.py
+++ b/tests/test_two_spheres.py
@@ -25,10 +25,7 @@ def test_two_sphere(key):
     with open('two_sphere.pickle', 'rb') as f:
         base_results = pickle.load(f)
 
-    if base_results[key] > 0:
-        assert abs(base_results[key] - results[key]) / base_results[key] < 1e-12
-    else:
-        assert base_results[key] == results[key]
+    assert abs(base_results[key] - results[key]) / (abs(base_results[key]) + 1e-16) < 1e-12
 
 def test_two_sphere_iterations():
     results = get_results()


### PR DESCRIPTION
PyGBe supports Cuda 8.0 now, so there's no reason to check the version
of nvcc that's present, just to check that nvcc is on PATH

Also there was a particularly silly bit of code in here (that I wrote) that
used an if statement to check whether or not to take the abs() of some
values. That has been removed since it was useless.

The only caveat is that the two_spheres problem sometimes has zero
values, so I've also added a 1e-16 to the denominator of that test so we
don't get a NaN.