### PR TITLE
Read fields

### DIFF
--- a/docs/programmatic.rst
+++ b/docs/programmatic.rst
@@ -60,24 +60,19 @@ For reference, the config dictionary equivalent to the Lysozyme example would lo
 
 .. code:: python
 
-    lys_field = {'E': ['80', '80', '4', '80', '80', '80'],
-                'LorY': ['2', '1', '1', '1', '1', '1'],
-                'Nchild': ['1', '1', '3', '0', '0', '0'],
-                'Nparent': ['0', '1', '1', '1', '1', '1'],
-                'charges': ['0', '0', '1', '0', '0', '0'],
-                'child': ['0', '1', '2', '3', '4'],
-                'coulomb': ['0', '0', '1', '0', '0', '0'],
-                'kappa': ['0.125', '1e-12', '1e-12', '1e-12', '1e-12', '1e-12'],
-                'parent': ['NA', '0', '1', '2', '3', '4'],
-                'pot': ['0', '0', '1', '0', '0', '0'],
+    lys_field = {'E': [80, 80, 4, 80, 80, 80],
+                'LorY': [2, 1, 1, 1, 1, 1],
+                'Nchild': [1, 1, 3, 0, 0, 0],
+                'Nparent': [0, 1, 1, 1, 1, 1],
+                'charges': [0, 0, 1, 0, 0, 0],
+                'child': [0, 1, 2, 3, 4],
+                'coulomb': [0, 0, 1, 0, 0, 0],
+                'kappa': [0.125, 1e-12, 1e-12, 1e-12, 1e-12, 1e-12],
+                'parent': ['NA', 0, 1, 2, 3, 4],
+                'pot': [0, 0, 1, 0, 0, 0],
                 'qfile': ['NA',
                 'NA',
                 '/home/gil/git/pygbe/examples/lys/lys1_charges.pqr',
                 'NA'
                 'NA',
                 'NA']}
-
-.. note:: Numeric values can be strings or ints or floats -- they will be
-          converted accordingly.
-          
-

--- a/pygbe/class_initialization.py
+++ b/pygbe/class_initialization.py
@@ -2,7 +2,7 @@
 It contains the necessary functions to set up the surface to be solved.
 """
 
-from pygbe.util.read_data import readFields, read_surface
+from pygbe.util.read_data import read_fields, read_surface
 from pygbe.classes import Field, Surface
 
 
@@ -56,14 +56,13 @@ def initialize_field(filename, param, field=None):
     """
 
     if not field:
-        field = readFields(filename)
+        field = read_fields(filename)
 
-        field['LorY'] = [int(i) if i != 'NA' else 0 for i in field['LorY']]
-        field['E'] = [complex(i) if 'j' in i else param.REAL(i) if i != 'NA' else 0
-            for i in field['E']]
-        field['kappa'] = [param.REAL(i) if i != 'NA' else 0 for i in field['kappa']]
-        field['pot'] = [int(i) for i in field['pot']]
-        field['coulomb'] = [int(i) for i in field['coulomb']]
+    for key in ['E', 'kappa']:
+        for i, e in enumerate(field[key]):
+            if not isinstance(e, complex):
+                field[key][i] = param.REAL(field[key][i])
+
     Nfield = len(field['LorY'])
     field_array = []
     Nchild_aux = 0

--- a/pygbe/class_initialization.py
+++ b/pygbe/class_initialization.py
@@ -60,7 +60,7 @@ def initialize_field(filename, param, field=None):
 
     for key in ['E', 'kappa']:
         for i, e in enumerate(field[key]):
-            if not isinstance(e, complex):
+            if not isinstance(e, complex) and not isinstance(e, str):
                 field[key][i] = param.REAL(field[key][i])
 
     Nfield = len(field['LorY'])

--- a/pygbe/class_initialization.py
+++ b/pygbe/class_initialization.py
@@ -58,12 +58,12 @@ def initialize_field(filename, param, field=None):
     if not field:
         field = readFields(filename)
 
-    field['LorY'] = [int(i) if i != 'NA' else 0 for i in field['LorY']]
-    field['E'] = [complex(i) if 'j' in i else param.REAL(i) if i != 'NA' else 0
-         for i in field['E']]
-    field['kappa'] = [param.REAL(i) if i != 'NA' else 0 for i in field['kappa']]
-    field['pot'] = [int(i) for i in field['pot']]
-    field['coulomb'] = [int(i) for i in field['coulomb']]
+        field['LorY'] = [int(i) if i != 'NA' else 0 for i in field['LorY']]
+        field['E'] = [complex(i) if 'j' in i else param.REAL(i) if i != 'NA' else 0
+            for i in field['E']]
+        field['kappa'] = [param.REAL(i) if i != 'NA' else 0 for i in field['kappa']]
+        field['pot'] = [int(i) for i in field['pot']]
+        field['coulomb'] = [int(i) for i in field['coulomb']]
     Nfield = len(field['LorY'])
     field_array = []
     Nchild_aux = 0

--- a/pygbe/util/read_data.py
+++ b/pygbe/util/read_data.py
@@ -218,7 +218,7 @@ def readParameters(param, filename):
     return dataType
 
 
-def readFields(filename):
+def read_fields(filename):
     """
     Read the physical parameters from the configuration file for each region
     in the surface
@@ -288,6 +288,16 @@ def readFields(filename):
                 field['Nchild'].append(line[10])
                 for i in range(int(field['Nchild'][-1])):
                     field['child'].append(line[11 + i])
+
+    for key in ['LorY', 'Nparent', 'parent', 'Nchild', 'child',
+                'pot', 'coulomb', 'charges']:
+        field[key] = [int(i) if i != 'NA' else 0 for i in field[key]]
+
+    # NOTE: We ignore the value of `param.REAL` here but cast down in
+    # `class_initialization.initialize_field` if necessary
+    field['E'] = [complex(i) if 'j' in i else float(i) if i != 'NA' else 0
+        for i in field['E']]
+    field['kappa'] = [float(i) if i != 'NA' else 0 for i in field['kappa']]
 
     return field
 


### PR DESCRIPTION
Small changes to the way fields are read in -- we don't leave them as strings to make it easier to use a dictionary to pass in new config values programmatically.

Also removed the camelCase. Note that these commits were initially made in the `lspr` branch and I have cherry picked them to merge them into master independently.