### PR TITLE
small change to doctr deploy API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ script:
   - cd docs
   - make html
   - cd ..
-  - python -m doctr deploy
+  - python -m doctr deploy docs
 


### PR DESCRIPTION
``--gh-pages-docs`` flag is deprecated and deploy directory is now a required
argument.