### PR TITLE
Fix for failed doc builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no 
   - conda config --add channels conda-forge
-  - conda create -q -n pygbe python=3.5 numpy scipy swig sphinx
+  - conda create -q -n pygbe python=3.5 numpy scipy swig sphinx=1.7.0
   - source activate pygbe
   - pip install doctr
 


### PR DESCRIPTION
sphinx is apparently completely screwed after version 1.7.0

I was getting conflicting error messages and the help screens claim that
`-d` is both a "max depth" argument but also "input directory"

In any case, pinning sphinx to 1.7.0 appears to fix the issue.

Make sure that this passes CI first, though, in case I missed something.