### PR TITLE
Fix typo in param files of examples

### DIFF
--- a/examples/1PGBmut_sensor/1PGBmut_sensor.param
+++ b/examples/1PGBmut_sensor/1PGBmut_sensor.param
@@ -2,7 +2,7 @@ Precision   double
 K           1
 Nk          9
 K_fine      19
-thresold    0.5
+threshold   0.5
 BSZ         128
 restart     200
 tolerance   1e-5

--- a/examples/lspr_7_spheres/seven_sphere_complex.param
+++ b/examples/lspr_7_spheres/seven_sphere_complex.param
@@ -2,7 +2,7 @@ Precision   double
 K           3
 Nk          9  
 K_fine      37
-thresold    0.5
+threshold   0.5
 BSZ         128
 restart     100
 tolerance   1e-6

--- a/examples/lspr_gold/sphere_complex.param
+++ b/examples/lspr_gold/sphere_complex.param
@@ -2,7 +2,7 @@ Precision   double
 K           3
 Nk          9  
 K_fine      37
-thresold    0.5
+threshold   0.5
 BSZ         128
 restart     100
 tolerance   1e-6

--- a/examples/lspr_silver/sphere_complex.param
+++ b/examples/lspr_silver/sphere_complex.param
@@ -2,7 +2,7 @@ Precision   double
 K           3
 Nk          9  
 K_fine      37
-thresold    0.5
+threshold   0.5
 BSZ         128
 restart     100
 tolerance   1e-6

--- a/examples/lys/lys.param
+++ b/examples/lys/lys.param
@@ -2,7 +2,7 @@ Precision   double
 K           1
 Nk          5   
 K_fine      19
-thresold    0.8
+threshold   0.8
 BSZ         128
 restart     200
 tolerance   1e-4

--- a/examples/sphere/sphere.param
+++ b/examples/sphere/sphere.param
@@ -2,7 +2,7 @@ Precision   double
 K           3
 Nk          9  
 K_fine      37
-thresold    0.5
+threshold   0.5
 BSZ         128
 restart     100
 tolerance   1e-6

--- a/examples/two_spheres/two_spheres.param
+++ b/examples/two_spheres/two_spheres.param
@@ -2,7 +2,7 @@ Precision   double
 K           3
 Nk          9  
 K_fine      37
-thresold    0.5
+threshold   0.5
 BSZ         128
 restart     100
 tolerance   1e-6


### PR DESCRIPTION
thresold ---> threshold
This doesn't affect the code since the function that
reads the parameters (read_parameters in util/read_data.py)
reads just numeric values.